### PR TITLE
no-op: Minor docs update ...

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+### 0.1.2.1
+
+* No-op improvements
+  * Minor documentation edits.
+
 ### 0.1.2.0
 
 * New features

--- a/squeal-postgresql-qq.cabal
+++ b/squeal-postgresql-qq.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.0
 name:                squeal-postgresql-qq
-version:             0.1.2.0
+version:             0.1.2.1
 synopsis:            QuasiQuoter transforming raw sql into Squeal expressions.
 -- description:         
 homepage:            https://github.com/owensmurray/squeal-postgresql-qq

--- a/src/Squeal/QuasiQuotes.hs
+++ b/src/Squeal/QuasiQuotes.hs
@@ -68,10 +68,10 @@ import qualified PostgresqlSyntax.Parsing as PGT_Parse
   See the [discussion](#discussion) section for why we monomorphize the
   squeal 'Statement' in this way.
 
-  = Haskell values
+  = Inline Haskell Values
 
-  The way you get Haskell values into your sql statements is with special
-  bulit-in sql functions:
+  If you don't want to use statement parameters, you can still get Haskell
+  values into your statements is with special bulit-in sql functions:
 
   * @inline(\<ident\>)@: Corresponds to
     'Squeal.PostgreSQL.Expression.Inline.inline' (value being inlined must
@@ -83,7 +83,7 @@ import qualified PostgresqlSyntax.Parsing as PGT_Parse
   where @\<ident\>@ is a haskell identifier in scope, whose type has an
   'Squeal.PostgreSQL.Inline' instance.
 
-  = Example
+  = Examples
 
   For the examples, let's assume you have a database like this:
 


### PR DESCRIPTION
... mostly the `inline` functions section, to indicate that these are
not the only officially supported ways to get Haskell values into your
statement.